### PR TITLE
Configure CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2.1
+
+references:
+  cache-key: &cache-key v2-m2-{{ checksum "project.clj" }}
+  docker: &docker
+    docker:
+      - image: circleci/clojure:lein-2.9.1
+jobs:    
+  build:
+    <<: *docker
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - *cache-key
+      - run: lein run
+      - save_cache:
+          key: *cache-key
+          paths:
+            - ~/.m2
+      - persist_to_workspace:
+          root: resources
+          paths:
+            - public
+  publish:
+    <<: *docker
+    steps:
+      - add_ssh_keys
+      - attach_workspace:
+          at: ~/workspace
+      - run:
+          name: Configure git
+          command: |
+            git config --global user.email "you@example.com"
+            git config --global user.name "Your Name"
+      - run:
+          name: Disable StrictHostKeyChecking
+          command: |
+            mkdir -p ~/.ssh
+            echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+      - run:
+          command: |
+            set -ex
+            cd ~
+            git clone git@github.com:ClojureTO/clojureto.github.io.git
+            cd clojureto.github.io
+            cp -r ../workspace/public/* ./
+            git commit -am "CircleCI deploy $CIRCLE_SHA1"
+            git push -f origin frank/test-ci-stuff
+
+workflows:
+  version: 2
+  build-and-publish:
+    jobs:
+      - build
+      - publish:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Configures a workflow consisting of a build job and a publish job. The publish job only runs on the master branch and pushes to the organization page repository.