### PR TITLE
Fix publish job in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             cd clojureto.github.io
             cp -r ../workspace/public/* ./
             git commit -am "CircleCI deploy $CIRCLE_SHA1"
-            git push -f origin frank/test-ci-stuff
+            git push -f origin master
 
 workflows:
   version: 2


### PR DESCRIPTION
This fixes the config to push to master instead of the frank/test-ci-stuff branch I was using to test the job.